### PR TITLE
ci: prevent `security-build` workflow to run on forks

### DIFF
--- a/.github/workflows/security-build.yml
+++ b/.github/workflows/security-build.yml
@@ -12,6 +12,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    if: github.repository == '0xPolygon/kurtosis-cdk'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description
<!-- Describe this change, how it works, and the motivation behind it. -->

Skip some jobs that will always fail on forks because the environment secrets are not defined.

## References (if applicable)
<!-- Add relevant Github Issues, Discord threads, or other helpful information. -->
<!-- You can auto-close issues by putting "Fixes #XXXX" here. -->
